### PR TITLE
Add spec expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 
+
+### Added
+- Add `#be_enqueued` spec expectation
+
 ## [1.0.3] - 2025-12-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -690,6 +690,8 @@ You may delete progress data in specs thus:
 
 # ...
 
+require "mel/spec"
+
 Spec.before_each do
   # ...
   Mel.settings.store.try(&.truncate_progress)
@@ -729,6 +731,10 @@ If it is a negative integer `-N`  (other than `-1`), the number of due tasks pul
 - `#be_enqueued`: This expectation can you be used to assert that a given job has been enqueued in the store:
 
   ```crystal
+  # ...
+
+  require "mel/spec"
+
   SendEmailJob.should be_enqueued
   SendEmailJob.should be_enqueued(id: "1234")
   SendEmailJob.should be_enqueued(count: 2)
@@ -742,6 +748,8 @@ If it is a negative integer `-N`  (other than `-1`), the number of due tasks pul
   SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
   SendEmailJob.should_not be_enqueued(id: "1234", as: Mel::PeridicTask)
   SendEmailJob.should_not be_enqueued(count: 2, as: Mel::InstantTask)
+
+  # ...
   ```
 
 ## Integrations

--- a/README.md
+++ b/README.md
@@ -721,6 +721,29 @@ If it is a negative integer `-N`  (other than `-1`), the number of due tasks pul
 
 `-1` sets *no* limits. *Mel* would pull as many tasks as are due each poll, and run all of them.
 
+### Spec Helpers
+
+*Mel* comes with helpers and expectations for use in your specs:
+
+- `Mel.start_and_stop`: Starts *Mel*, pulls due tasks from the queue and runs them. It stops immediately after.
+- `#be_enqueued`: This expectation can you be used to assert that a given job has been enqueued in the store:
+
+  ```crystal
+  SendEmailJob.should be_enqueued
+  SendEmailJob.should be_enqueued(id: "1234")
+  SendEmailJob.should be_enqueued(count: 2)
+  SendEmailJob.should be_enqueued(as: Mel::InstantTask)
+  SendEmailJob.should be_enqueued(id: "1234", as: Mel::PeridicTask)
+  SendEmailJob.should be_enqueued(count: 2, as: Mel::CronTask)
+
+  SendEmailJob.should_not be_enqueued
+  SendEmailJob.should_not be_enqueued(id: "1234")
+  SendEmailJob.should_not be_enqueued(count: 2)
+  SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
+  SendEmailJob.should_not be_enqueued(id: "1234", as: Mel::PeridicTask)
+  SendEmailJob.should_not be_enqueued(count: 2, as: Mel::InstantTask)
+  ```
+
 ## Integrations
 
 ### *Carbon* mailer

--- a/spec/mel/cron_task_spec.cr
+++ b/spec/mel/cron_task_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 describe Mel::CronTask do
   describe ".find" do
-    it "returns all periodic tasks" do
+    it "returns all cron tasks" do
       address = "user@domain.tld"
 
       SendEmailJob.run(address: address)

--- a/spec/mel/job/at_spec.cr
+++ b/spec/mel/job/at_spec.cr
@@ -21,6 +21,6 @@ describe Mel::Job::At do
       task.try(&.job.as(SendEmailAtJob).sent?).should be_true
     end
 
-    Mel::InstantTask.find(id).should be_nil
+    SendEmailAtJob.should_not be_enqueued(id)
   end
 end

--- a/spec/mel/job/every_spec.cr
+++ b/spec/mel/job/every_spec.cr
@@ -18,7 +18,7 @@ describe Mel::Job::Every do
       end
     end
 
-    Mel::PeriodicTask.find(id).should be_a(Mel::PeriodicTask)
+    SendEmailEveryJob.should be_enqueued(id, Mel::PeriodicTask)
   end
 
   it "starts at specified time" do

--- a/spec/mel/job_spec.cr
+++ b/spec/mel/job_spec.cr
@@ -14,7 +14,7 @@ describe Mel::Job do
       Mel.sync(task)
       task.try(&.job.as(SendEmailJob).sent?).should be_true
 
-      Mel::InstantTask.find(id).should be_nil
+      SendEmailJob.should_not be_enqueued(id)
     end
   end
 
@@ -39,7 +39,7 @@ describe Mel::Job do
         task.try(&.job.as(SendEmailJob).sent?).should be_true
       end
 
-      Mel::InstantTask.find(id).should be_nil
+      SendEmailJob.should_not be_enqueued(id)
     end
   end
 
@@ -64,7 +64,7 @@ describe Mel::Job do
         task.try(&.job.as(SendEmailJob).sent?).should be_true
       end
 
-      Mel::InstantTask.find(id).should be_nil
+      SendEmailJob.should_not be_enqueued(id)
     end
   end
 
@@ -86,7 +86,7 @@ describe Mel::Job do
         end
       end
 
-      Mel::PeriodicTask.find(id).should be_a(Mel::PeriodicTask)
+      SendEmailJob.should be_enqueued(id, Mel::PeriodicTask)
     end
 
     it "deletes task after given time" do
@@ -106,7 +106,7 @@ describe Mel::Job do
         end
       end
 
-      Mel::PeriodicTask.find(id).should be_nil
+      SendEmailJob.should_not be_enqueued(id)
     end
   end
 
@@ -149,7 +149,7 @@ describe Mel::Job do
         task.try(&.job.as(SendEmailJob).sent?).should be_true
       end
 
-      Mel::CronTask.find(id).should be_a(Mel::CronTask)
+      SendEmailJob.should be_enqueued(id, Mel::CronTask)
     end
 
     it "deletes task after given time" do
@@ -173,7 +173,7 @@ describe Mel::Job do
       end
 
       Timecop.travel(4.hours.from_now) do
-        Mel::CronTask.find(id).should be_nil
+        SendEmailJob.should_not be_enqueued(id)
       end
     end
   end

--- a/spec/mel/job_spec.cr
+++ b/spec/mel/job_spec.cr
@@ -302,7 +302,7 @@ describe Mel::Job do
 
       task.should_not be_nil
       Mel.sync(task)
-      Mel::InstantTask.find(-1).try(&.size).should eq(max)
+      CountJob.should be_enqueued(max, Mel::InstantTask)
     end
   end
 end

--- a/spec/mel/task_spec.cr
+++ b/spec/mel/task_spec.cr
@@ -164,10 +164,10 @@ describe Mel::Task do
       Mel::Task.find(-1).try(&.size).should eq(3)
       Mel::PeriodicTask.find(-1).try(&.size).should eq(1)
 
-      Mel::PeriodicTask.find(id).try(&.dequeue)
+      Mel::Task.find(id).try(&.dequeue)
 
       Mel::Task.find(-1).try(&.size).should eq(2)
-      Mel::PeriodicTask.find(-1).should be_nil
+      SendEmailJob.should_not be_enqueued(as: Mel::PeriodicTask)
     end
   end
 

--- a/spec/mel/task_spec.cr
+++ b/spec/mel/task_spec.cr
@@ -17,7 +17,7 @@ describe Mel::Task do
       Mel.sync(task)
       task.try(&.attempts).should eq(2)
 
-      Mel::InstantTask.find(id).should be_nil
+      FailedJob.should_not be_enqueued(id)
     end
 
     it "retries failed tasks with backoffs" do
@@ -27,22 +27,22 @@ describe Mel::Task do
 
       Timecop.freeze(Time.local) do
         Mel.start_and_stop(4)
-        Mel::InstantTask.find(id).should_not be_nil
+        FailedJob.should be_enqueued(id)
       end
 
       Timecop.travel(1.minute.from_now) do
         Mel.start_and_stop
-        Mel::InstantTask.find(id).should_not be_nil
+        FailedJob.should be_enqueued(id)
       end
 
       Timecop.travel(2.minutes.from_now) do
         Mel.start_and_stop
-        Mel::InstantTask.find(id).should_not be_nil
+        FailedJob.should be_enqueued(id)
       end
 
       Timecop.travel(3.minutes.from_now) do
         Mel.start_and_stop
-        Mel::InstantTask.find(id).should be_nil
+        FailedJob.should_not be_enqueued(id)
       end
     end
 
@@ -53,7 +53,7 @@ describe Mel::Task do
 
       Timecop.freeze(2.minutes.from_now) do
         Mel.start_and_stop
-        Mel::PeriodicTask.find(id).should_not be_nil
+        FailedJob.should be_enqueued(id)
       end
 
       Timecop.freeze(3.minutes.from_now) do
@@ -75,7 +75,7 @@ describe Mel::Task do
 
       Timecop.freeze(2.minutes.from_now) do
         Mel.start_and_stop
-        Mel::PeriodicTask.find(id).should_not be_nil
+        FailedJob.should be_enqueued(id)
       end
 
       Timecop.freeze(3.minutes.from_now) do

--- a/spec/mel/task_spec.cr
+++ b/spec/mel/task_spec.cr
@@ -119,7 +119,7 @@ describe Mel::Task do
       SendEmailJob.run(id, address: "aa@bb.cc")
       SendEmailJob.run(id, address: "dd@ee.ff")
 
-      Mel::InstantTask.find(-1).try(&.size).should eq(1)
+      SendEmailJob.should be_enqueued(1)
 
       Mel::InstantTask.find(id)
         .try(&.job.as(SendEmailJob).address)
@@ -134,7 +134,7 @@ describe Mel::Task do
       SendEmailJob.run(id, force: true, address: "dd@ee.ff")
       SendEmailJob.run(id, force: true, address: address)
 
-      Mel::InstantTask.find(-1).try(&.size).should eq(1)
+      SendEmailJob.should be_enqueued(1)
 
       Mel::InstantTask.find(id)
         .try(&.job.as(SendEmailJob).address)
@@ -148,7 +148,7 @@ describe Mel::Task do
       SendEmailJob.run(address: address)
       SendEmailJob.run(address: address)
 
-      Mel::InstantTask.find(-1).try(&.size).should eq(3)
+      SendEmailJob.should be_enqueued(3)
     end
   end
 
@@ -161,12 +161,12 @@ describe Mel::Task do
       SendEmailJob.run_every(10.minutes, id: id, address: address)
       SendEmailJob.run_on("0 2 * * *", for: 1.week, address: address)
 
-      Mel::Task.find(-1).try(&.size).should eq(3)
-      Mel::PeriodicTask.find(-1).try(&.size).should eq(1)
+      SendEmailJob.should be_enqueued(3)
+      SendEmailJob.should be_enqueued(1, Mel::PeriodicTask)
 
       Mel::Task.find(id).try(&.dequeue)
 
-      Mel::Task.find(-1).try(&.size).should eq(2)
+      SendEmailJob.should be_enqueued(2)
       SendEmailJob.should_not be_enqueued(as: Mel::PeriodicTask)
     end
   end

--- a/spec/spec/expectations_spec.cr
+++ b/spec/spec/expectations_spec.cr
@@ -1,0 +1,60 @@
+require "../spec_helper"
+
+describe Mel::BeEnqueuedExpectation do
+  describe "#be_enqueued" do
+    context "in positive assertions" do
+      it "passes if job is enqueued" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+        SendEmailJob.should be_enqueued(as: Mel::InstantTask)
+      end
+
+      it "fails if job is not enqueued" do
+        expect_raises Spec::AssertionFailed, "to be enqueued" do
+          SendEmailJob.should be_enqueued
+        end
+
+        expect_raises Spec::AssertionFailed, "to be enqueued as " do
+          SendEmailJob.should be_enqueued(as: Mel::InstantTask)
+        end
+      end
+
+      it "fails if expected type does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+
+        expect_raises Spec::AssertionFailed, "to be enqueued as " do
+          SendEmailJob.should be_enqueued(as: Mel::RecurringTask)
+        end
+      end
+    end
+
+    context "in negative assertions" do
+      it "passes if job is not enqueued" do
+        SendEmailJob.should_not be_enqueued
+        SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
+      end
+
+      it "fails if job is enqueued" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        expect_raises Spec::AssertionFailed, "to not be enqueued" do
+          SendEmailJob.should_not be_enqueued
+        end
+
+        expect_raises Spec::AssertionFailed, "to not be enqueued as " do
+          SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
+        end
+      end
+
+      it "passes if expected type does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued(as: Mel::InstantTask)
+        SendEmailJob.should_not be_enqueued(as: Mel::CronTask)
+      end
+    end
+  end
+end

--- a/spec/spec/expectations_spec.cr
+++ b/spec/spec/expectations_spec.cr
@@ -23,12 +23,26 @@ describe Mel::BeEnqueuedExpectation do
         SendEmailJob.should be_enqueued(2)
       end
 
+      it "passes if ID matches" do
+        id = "1001"
+        SendEmailJob.run(id: id, address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued(id)
+      end
+
       it "passes if both count and type match" do
         SendEmailJob.run(address: "user@domain.tld")
         SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
 
         SendEmailJob.should be_enqueued(1, as: Mel::PeriodicTask)
         SendEmailJob.should be_enqueued(1, as: Mel::RecurringTask)
+      end
+
+      it "passes if ID and type match" do
+        id = "1001"
+        SendEmailJob.run_every(1.hour, id: id, address: "newuser@domain.tld")
+
+        SendEmailJob.should be_enqueued(id, as: Mel::PeriodicTask)
       end
 
       it "fails if job is not enqueued" do
@@ -57,6 +71,14 @@ describe Mel::BeEnqueuedExpectation do
         end
       end
 
+      it "fails if ID does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        expect_raises Spec::AssertionFailed, " be enqueued" do
+          SendEmailJob.should be_enqueued("1002")
+        end
+      end
+
       it "fails if both count and type do not match" do
         SendEmailJob.run(address: "user@domain.tld")
 
@@ -64,6 +86,16 @@ describe Mel::BeEnqueuedExpectation do
 
         expect_raises Spec::AssertionFailed, " exactly 2 times as " do
           SendEmailJob.should be_enqueued(2, Mel::CronTask)
+        end
+      end
+
+      it "fails if both ID and type do not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+
+        expect_raises Spec::AssertionFailed, " be enqueued as " do
+          SendEmailJob.should be_enqueued("1002", Mel::CronTask)
         end
       end
     end
@@ -87,11 +119,24 @@ describe Mel::BeEnqueuedExpectation do
         SendEmailJob.should_not be_enqueued(4)
       end
 
+      it "passes if ID does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should_not be_enqueued("1002")
+      end
+
       it "passes if both count and type do not match" do
         SendEmailJob.run(address: "user@domain.tld")
 
         SendEmailJob.should be_enqueued
         SendEmailJob.should_not be_enqueued(3, as: Mel::CronTask)
+      end
+
+      it "passes if both ID and type do not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+        SendEmailJob.should_not be_enqueued("1002", as: Mel::CronTask)
       end
 
       it "fails if job is enqueued" do
@@ -123,6 +168,15 @@ describe Mel::BeEnqueuedExpectation do
         end
       end
 
+      it "fails if ID matches" do
+        id = "1001"
+        SendEmailJob.run(id: id, address: "user@domain.tld")
+
+        expect_raises Spec::AssertionFailed, " not be enqueued" do
+          SendEmailJob.should_not be_enqueued(id)
+        end
+      end
+
       it "fails if both count and type match" do
         SendEmailJob.run(address: "user@domain.tld")
         SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
@@ -142,6 +196,15 @@ describe Mel::BeEnqueuedExpectation do
           " not be enqueued exactly once as "
         ) do
           SendEmailJob.should_not be_enqueued(1, as: Mel::RecurringTask)
+        end
+      end
+
+      it "fails if both ID and type match" do
+        id = "1001"
+        SendEmailJob.run_every(1.hour, id: id, address: "newuser@domain.tld")
+
+        expect_raises Spec::AssertionFailed, " not be enqueued as " do
+          SendEmailJob.should_not be_enqueued(id, as: Mel::PeriodicTask)
         end
       end
     end

--- a/spec/spec/expectations_spec.cr
+++ b/spec/spec/expectations_spec.cr
@@ -7,26 +7,63 @@ describe Mel::BeEnqueuedExpectation do
         SendEmailJob.run(address: "user@domain.tld")
 
         SendEmailJob.should be_enqueued
-        SendEmailJob.should be_enqueued(as: Mel::InstantTask)
+      end
+
+      it "passes if type matches" do
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
+
+        SendEmailJob.should be_enqueued(as: Mel::PeriodicTask)
+        SendEmailJob.should be_enqueued(as: Mel::RecurringTask)
+      end
+
+      it "passes if count matches" do
+        SendEmailJob.run(address: "user@domain.tld")
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
+
+        SendEmailJob.should be_enqueued(2)
+      end
+
+      it "passes if both count and type match" do
+        SendEmailJob.run(address: "user@domain.tld")
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
+
+        SendEmailJob.should be_enqueued(1, as: Mel::PeriodicTask)
+        SendEmailJob.should be_enqueued(1, as: Mel::RecurringTask)
       end
 
       it "fails if job is not enqueued" do
-        expect_raises Spec::AssertionFailed, "to be enqueued" do
+        expect_raises Spec::AssertionFailed, " be enqueued" do
           SendEmailJob.should be_enqueued
-        end
-
-        expect_raises Spec::AssertionFailed, "to be enqueued as " do
-          SendEmailJob.should be_enqueued(as: Mel::InstantTask)
         end
       end
 
-      it "fails if expected type does not match" do
+      it "fails if type does not match" do
         SendEmailJob.run(address: "user@domain.tld")
 
         SendEmailJob.should be_enqueued
 
-        expect_raises Spec::AssertionFailed, "to be enqueued as " do
+        expect_raises Spec::AssertionFailed, " be enqueued as " do
           SendEmailJob.should be_enqueued(as: Mel::RecurringTask)
+        end
+      end
+
+      it "fails if count does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+
+        expect_raises Spec::AssertionFailed, " be enqueued exactly 4 times" do
+          SendEmailJob.should be_enqueued(4)
+        end
+      end
+
+      it "fails if both count and type do not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+
+        expect_raises Spec::AssertionFailed, " exactly 2 times as " do
+          SendEmailJob.should be_enqueued(2, Mel::CronTask)
         end
       end
     end
@@ -34,26 +71,78 @@ describe Mel::BeEnqueuedExpectation do
     context "in negative assertions" do
       it "passes if job is not enqueued" do
         SendEmailJob.should_not be_enqueued
-        SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
+      end
+
+      it "passes if type does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+        SendEmailJob.should_not be_enqueued(as: Mel::CronTask)
+      end
+
+      it "passes if count does not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+        SendEmailJob.should_not be_enqueued(4)
+      end
+
+      it "passes if both count and type do not match" do
+        SendEmailJob.run(address: "user@domain.tld")
+
+        SendEmailJob.should be_enqueued
+        SendEmailJob.should_not be_enqueued(3, as: Mel::CronTask)
       end
 
       it "fails if job is enqueued" do
         SendEmailJob.run(address: "user@domain.tld")
 
-        expect_raises Spec::AssertionFailed, "to not be enqueued" do
+        expect_raises Spec::AssertionFailed, " not be enqueued" do
           SendEmailJob.should_not be_enqueued
-        end
-
-        expect_raises Spec::AssertionFailed, "to not be enqueued as " do
-          SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
         end
       end
 
-      it "passes if expected type does not match" do
-        SendEmailJob.run(address: "user@domain.tld")
+      it "fails if type matches" do
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
 
-        SendEmailJob.should be_enqueued(as: Mel::InstantTask)
-        SendEmailJob.should_not be_enqueued(as: Mel::CronTask)
+        expect_raises Spec::AssertionFailed, " not be enqueued as " do
+          SendEmailJob.should_not be_enqueued(as: Mel::PeriodicTask)
+        end
+
+        expect_raises Spec::AssertionFailed, " not be enqueued as " do
+          SendEmailJob.should_not be_enqueued(as: Mel::RecurringTask)
+        end
+      end
+
+      it "fails if count matches" do
+        SendEmailJob.run(address: "user@domain.tld")
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
+
+        expect_raises Spec::AssertionFailed, " not be enqueued exactly 2 " do
+          SendEmailJob.should_not be_enqueued(2)
+        end
+      end
+
+      it "fails if both count and type match" do
+        SendEmailJob.run(address: "user@domain.tld")
+        SendEmailJob.run_every(1.hour, address: "newuser@domain.tld")
+
+        SendEmailJob.should be_enqueued(1, as: Mel::PeriodicTask)
+        SendEmailJob.should be_enqueued(1, as: Mel::RecurringTask)
+
+        expect_raises(
+          Spec::AssertionFailed,
+          " not be enqueued exactly once as "
+        ) do
+          SendEmailJob.should_not be_enqueued(1, as: Mel::PeriodicTask)
+        end
+
+        expect_raises(
+          Spec::AssertionFailed,
+          " not be enqueued exactly once as "
+        ) do
+          SendEmailJob.should_not be_enqueued(1, as: Mel::RecurringTask)
+        end
       end
     end
   end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -1,4 +1,5 @@
 require "./mel"
+require "./spec/**"
 
 module Mel
   def start_and_stop(count : Int = 1)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -1,13 +1,27 @@
-def be_enqueued(count : Int32? = nil, as type = nil)
-  Mel::BeEnqueuedExpectation.new(count, type)
+def be_enqueued(as type = nil)
+  Mel::BeEnqueuedExpectation.new(type)
 end
 
 def be_enqueued(count : Int, as type = nil)
-  Mel::BeEnqueuedExpectation.new(count.to_i, type)
+  Mel::BeEnqueuedExpectation.new(count, type)
+end
+
+def be_enqueued(id : String, as type = nil)
+  Mel::BeEnqueuedExpectation.new(id, type)
 end
 
 struct Mel::BeEnqueuedExpectation
-  def initialize(@count : Int32? = nil, @type : Mel::Task.class | Nil = nil)
+  @count : Int32?
+  @id : String?
+
+  def initialize(@type : Mel::Task.class | Nil = nil)
+  end
+
+  def initialize(count : Int, @type : Mel::Task.class | Nil = nil)
+    @count = count.to_i
+  end
+
+  def initialize(@id : String, @type : Mel::Task.class | Nil = nil)
   end
 
   def self.new(count : Int, type = nil)
@@ -15,7 +29,9 @@ struct Mel::BeEnqueuedExpectation
   end
 
   def match(job : Mel::Job::Template.class)
-    count = Mel::Task.find(-1).try &.count do |task|
+    find = @id.nil? ? -1 : {@id.not_nil!}
+
+    count = Mel::Task.find(find).try &.count do |task|
       next false unless task.job.class == job
       @type.nil? || task.class <= @type.not_nil!
     end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -24,10 +24,6 @@ struct Mel::BeEnqueuedExpectation
   def initialize(@id : String, @type : Mel::Task.class | Nil = nil)
   end
 
-  def self.new(count : Int, type = nil)
-    new(count.to_i, type)
-  end
-
   def match(job : Mel::Job::Template.class)
     find = @id.nil? ? -1 : {@id.not_nil!} # ameba:disable Lint/NotNil
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -29,11 +29,11 @@ struct Mel::BeEnqueuedExpectation
   end
 
   def match(job : Mel::Job::Template.class)
-    find = @id.nil? ? -1 : {@id.not_nil!}
+    find = @id.nil? ? -1 : {@id.not_nil!} # ameba:disable Lint/NotNil
 
     count = Mel::Task.find(find).try &.count do |task|
       next false unless task.job.class == job
-      @type.nil? || task.class <= @type.not_nil!
+      @type.nil? || task.class <= @type.not_nil! # ameba:disable Lint/NotNil
     end
 
     return false if count.nil?

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -1,31 +1,42 @@
-def be_enqueued(as type : Mel::Task.class | Nil = nil)
-  Mel::BeEnqueuedExpectation.new(type)
+def be_enqueued(count : Int32? = nil, as type = nil)
+  Mel::BeEnqueuedExpectation.new(count, type)
+end
+
+def be_enqueued(count : Int, as type = nil)
+  Mel::BeEnqueuedExpectation.new(count.to_i, type)
 end
 
 struct Mel::BeEnqueuedExpectation
-  def initialize(@type : Mel::Task.class | Nil = nil)
+  def initialize(@count : Int32? = nil, @type : Mel::Task.class | Nil = nil)
+  end
+
+  def self.new(count : Int, type = nil)
+    new(count.to_i, type)
   end
 
   def match(job : Mel::Job::Template.class)
-    Mel::Task.find(-1).try &.any? do |task|
+    count = Mel::Task.find(-1).try &.count do |task|
       next false unless task.job.class == job
       @type.nil? || task.class <= @type.not_nil!
     end
+
+    return false if count.nil?
+    @count.nil? ? count > 0 : count == @count
   end
 
   def failure_message(job : Mel::Job::Template.class)
-    @type.try do |type|
-      return "Expected #{job} to be enqueued as #{type}"
-    end
-
-    "Expected #{job} to be enqueued"
+    "Expected #{job} to be enqueued#{failure_message_suffix}"
   end
 
   def negative_failure_message(job : Mel::Job::Template.class)
-    @type.try do |type|
-      return "Expected #{job} to not be enqueued as #{type}"
-    end
+    "Expected #{job} to not be enqueued#{failure_message_suffix}"
+  end
 
-    "Expected #{job} to not be enqueued"
+  private def failure_message_suffix
+    times_part = @count == 1 ? "once" : "#{@count} times"
+    count_part = @count.nil? ? "" : " exactly #{times_part}"
+    type_part = @type.nil? ? "" : " as #{@type}"
+
+    "#{count_part}#{type_part}"
   end
 end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -1,0 +1,31 @@
+def be_enqueued(as type : Mel::Task.class | Nil = nil)
+  Mel::BeEnqueuedExpectation.new(type)
+end
+
+struct Mel::BeEnqueuedExpectation
+  def initialize(@type : Mel::Task.class | Nil = nil)
+  end
+
+  def match(job : Mel::Job::Template.class)
+    Mel::Task.find(-1).try &.any? do |task|
+      next false unless task.job.class == job
+      @type.nil? || task.class <= @type.not_nil!
+    end
+  end
+
+  def failure_message(job : Mel::Job::Template.class)
+    @type.try do |type|
+      return "Expected #{job} to be enqueued as #{type}"
+    end
+
+    "Expected #{job} to be enqueued"
+  end
+
+  def negative_failure_message(job : Mel::Job::Template.class)
+    @type.try do |type|
+      return "Expected #{job} to not be enqueued as #{type}"
+    end
+
+    "Expected #{job} to not be enqueued"
+  end
+end


### PR DESCRIPTION
Add expectations for use in specs:

```crystal
  SendEmailJob.should be_enqueued
  SendEmailJob.should be_enqueued(id: "1234")
  SendEmailJob.should be_enqueued(count: 2)
  SendEmailJob.should be_enqueued(as: Mel::InstantTask)
  SendEmailJob.should be_enqueued(id: "1234", as: Mel::PeridicTask)
  SendEmailJob.should be_enqueued(count: 2, as: Mel::CronTask)

  SendEmailJob.should_not be_enqueued
  SendEmailJob.should_not be_enqueued(id: "1234")
  SendEmailJob.should_not be_enqueued(count: 2)
  SendEmailJob.should_not be_enqueued(as: Mel::InstantTask)
  SendEmailJob.should_not be_enqueued(id: "1234", as: Mel::PeridicTask)
  SendEmailJob.should_not be_enqueued(count: 2, as: Mel::InstantTask)
  ```

@wout does this help with #7? It should simplify your use case to:

```crystal
SignUpUserWithSite.create!(**valid_params) # <= job enqueued in here
Email::VerificationJob.should be_enqueued(as: Mel::InstantTask)
```